### PR TITLE
Improving script versions view

### DIFF
--- a/app/controllers/scripts/versions_controller.rb
+++ b/app/controllers/scripts/versions_controller.rb
@@ -6,7 +6,9 @@ class Scripts::VersionsController < ApplicationController
   respond_to :html
 
   def index
-    @versions = @script.versions.reorder(created_at: :desc).page params[:page]
+    @versions = @script.versions_with_text_changes.reorder(
+      created_at: :desc
+    ).preload(:user).page params[:page]
 
     respond_with @versions
   end

--- a/app/helpers/scripts/versions_helper.rb
+++ b/app/helpers/scripts/versions_helper.rb
@@ -1,25 +1,21 @@
 module Scripts::VersionsHelper
-  def version_user_for version
-    originator = version.paper_trail_originator || version.whodunnit
-
-    User.find originator if originator
-  end
-
   def version_change_for version
-    version.event == 'create' ? t('scripts.versions.index.event.create') : (version.reify&.change || '-')
+    change = version.object_changes['change']&.last || (version.reify&.change || '-')
+
+    if version.event == 'create'
+      change += " (#{t 'scripts.versions.index.event.create'})"
+    end
+
+    change
   end
 
   def version_change_date_for version
-    version.reify&.updated_at || version.created_at
+    version.created_at
   end
 
-  def version_diff_to_previous
-    previous = @version.previous
+  def text_diff_for_version
+    previous, current = *@version.object_changes['text']
 
-    if previous
-      raw Diffy::Diff.new(previous.reify&.text, @version.reify&.text, include_plus_and_minus_in_html: true)
-    else
-      content_tag :p, t('.no_previous'), class: 'lead'
-    end
+    raw Diffy::Diff.new(previous, current, include_plus_and_minus_in_html: true)
   end
 end

--- a/app/models/concerns/scripts/versions.rb
+++ b/app/models/concerns/scripts/versions.rb
@@ -1,0 +1,9 @@
+module Scripts::Versions
+  extend ActiveSupport::Concern
+
+  def versions_with_text_changes
+    versions.where(
+      "#{versions.table_name}.object_changes ->> 'text' IS NOT NULL"
+    )
+  end
+end

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,0 +1,8 @@
+class PaperTrail::Version < ::ActiveRecord::Base
+  include PaperTrail::VersionConcern
+
+  belongs_to :user,
+    foreign_key: :whodunnit,
+    class_name: User.name,
+    optional: true
+end

--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -16,6 +16,7 @@ class Script < ApplicationRecord
   include Scripts::Requires
   include Scripts::Scopes
   include Scripts::Validation
+  include Scripts::Versions
   include Filterable
   include Taggable
 

--- a/app/views/scripts/versions/index.html.erb
+++ b/app/views/scripts/versions/index.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% @versions.each do |version| %>
         <tr>
-          <td><%= version_user_for version %></td>
+          <td><%= version.user %></td>
           <td class="hidden-sm hidden-xs"><%= truncate version_change_for(version) %></td>
           <td><%= l version_change_date_for(version), format: :compact %></td>
           <td><%= link_to_show script_version_path(@script, version) %></td>

--- a/app/views/scripts/versions/show.html.erb
+++ b/app/views/scripts/versions/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
-    <%= version_diff_to_previous %>
+    <%= text_diff_for_version %>
   </div>
 </div>
 

--- a/config/locales/views.es.yml
+++ b/config/locales/views.es.yml
@@ -285,7 +285,6 @@ es:
           create: 'Creación'
       show:
         title: 'Ver versión'
-        no_previous: 'Primer versión'
 
   schedules:
     edit:

--- a/test/helpers/scripts/versions_helper_test.rb
+++ b/test/helpers/scripts/versions_helper_test.rb
@@ -1,12 +1,6 @@
 require 'test_helper'
 
 class Scripts::VersionsHelperTest < ActionView::TestCase
-  test 'version user for' do
-    version = versions :cd_root_creation
-
-    assert_kind_of User, version_user_for(version)
-  end
-
   test 'version change for' do
     version = versions :cd_root_creation
 
@@ -19,10 +13,10 @@ class Scripts::VersionsHelperTest < ActionView::TestCase
     assert_kind_of Time, version_change_date_for(version)
   end
 
-  test 'version diff to previous' do
-    @virtual_path = ''
+  test 'text diff for version' do
     @version = versions :cd_root_creation
+    @version.update_column :object_changes, { 'text' => [nil, 'puts "Hola mundo"'] }
 
-    assert_kind_of String, version_diff_to_previous
+    assert_kind_of String, text_diff_for_version
   end
 end

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -265,6 +265,22 @@ class ScriptTest < ActiveSupport::TestCase
     skip
   end
 
+  test 'versions with text changes' do
+    script = Script.create!(
+      name:   'Hello world',
+      text:   'puts "Hello world"',
+      change: 'Initial'
+    )
+
+    assert_equal 1, script.versions_with_text_changes.count
+
+    assert_difference 'PaperTrail::Version.count' do
+      assert_no_difference 'script.versions_with_text_changes.count' do
+        script.update name: 'Super hello world', change: 'change title'
+      end
+    end
+  end
+
   private
 
     def syntax_errors_for code


### PR DESCRIPTION
- We only show versions with text changes (in the script versions index).
- Instead of reify to get the info, we use object changes to show the diff between them.
- Show the real creation date of the version (created_at).
- In creation event we show a legend (Creation) next to the change.
- Add a little users cache for version creator (whodunnit)