### PR TITLE
Preloading Issue.to_pdf

### DIFF
--- a/app/models/concerns/issues/export_data.rb
+++ b/app/models/concerns/issues/export_data.rb
@@ -31,7 +31,7 @@ module Issues::ExportData
       files = []
 
       ::Zip::File.open file, Zip::File::CREATE do |zipfile|
-        all.map { |issue| files << issue.add_to_zip(zipfile) }
+        all.each { |issue| files << issue.add_to_zip(zipfile) }
       end
 
       data_file_path file, files

--- a/app/models/concerns/issues/pdf.rb
+++ b/app/models/concerns/issues/pdf.rb
@@ -119,7 +119,7 @@ module Issues::PDF
         pdf.text I18n.t('issues.pdf.details'), size: 16
         pdf.move_down 6
 
-        statuses = I18n.t('issues.status')
+        statuses = I18n.t 'issues.status'
 
         @scoped.each do |issue|
           last_comment = issue.last_comment

--- a/app/models/concerns/issues/pdf.rb
+++ b/app/models/concerns/issues/pdf.rb
@@ -17,7 +17,7 @@ module Issues::PDF
         pdf.text I18n.t('issues.pdf.title'), size: 16
         pdf.move_down 6
 
-        @scoped = all.includes(:script).ordered_by_script_name.order(created_at: :asc).preload(
+        @scoped = all.includes(:script).ordered_by_script_name.order(:created_at).preload(
           :tags, last_comment: :user, script: :descriptions
         )
 
@@ -65,7 +65,6 @@ module Issues::PDF
       end
 
       def put_issues_by_month_on pdf
-        data           = [issues_by_month_headers]
         grouped_issues = @scoped.group_by do |issue|
           issue.created_at.to_date.beginning_of_month
         end
@@ -74,7 +73,7 @@ module Issues::PDF
         pdf.move_down 6
 
         grouped_issues.each do |month, issues|
-          issues_data = data.dup
+          issues_data = [issues_by_month_headers]
 
           issues.group_by(&:script).each do |script, issues|
             issues_data << [script.to_s, issues.size, issue_tag_list(issues)]


### PR DESCRIPTION
- Estuve revisando un poco como se estaba armarndo el pdf, y se hacían muchas queries para traer los issues, así que lo pase a un gran preload y selects.
- Le agregué el `to_date` aun group_by:
```ruby
a = Time.now                                                                                
Benchmark.bm {|bm| bm.report { 1_000_000.times { a.beginning_of_month }} } # => 19.80s      
Benchmark.bm {|bm| bm.report { 1_000_000.times { a.to_date.beginning_of_month }} } #=> 2.19s
```

Testie el performance del to_pdf de la sgte manera:
```ruby
attrs = {"status"=>"pending", "description"=>"Ls on Atahualpa aparently is not working again", "data"=>{"test"=>"data"}, "run_id"=>760740619, "lock_version"=>0}

500.times { Issue.create(attrs.merge('status' => 'pending')).comments.create(text: 'tangalanga', user_id: 1047776428) }
500.times { Issue.create(attrs.merge('status' => 'taken')).comments.create(text: 'tangalanga', user_id: 1047776428) }
n = 0
Issue.where(status: :pending).limit(250).each {|i| i.tags.create!(name: (n += 1).to_s + 'tanga') }
Issue.where(status: :taken).limit(250).each {|i| i.tags.create(name: (n += 1).to_s + 'tanga')}

Benchmark.bm { |bm| bm.report { Issue.to_pdf } }
# Master => 19.8s
# Branch => 14s~
```
Se podría decir que es casi un 30% de mejora solo cargando una vez. 

Estaría bueno que bajes este branch en la maquina de prod, y corras el to_pdf a ver si mejora o se sigue rajando.