### PR TITLE
GS-38_Add_popover_for_cells_with_arrays_or_hashes

### DIFF
--- a/app/views/issues/_issue_alt.html.erb
+++ b/app/views/issues/_issue_alt.html.erb
@@ -4,7 +4,16 @@
 <tr data-issue="<%= issue.id %>">
 
   <% data.to_a[0...-1].each do |_header, value| %>
-    <td><%= value %></td>
+    <td>
+      <% if value.kind_of?(Hash) || value.kind_of?(Array) %>
+        <a role="button" data-toggle="popover" data-placement="top" data-html="true"
+          data-content="<%= render partial: 'popover', locals: { value: value } %>">
+          <i class="fas fa-search"></i>
+        </a>
+      <% else %>
+        <%= value %>
+      <% end %>
+    </td>
   <% end %>
 
   <td class="d-none d-sm-table-cell"><%= issue_status issue %></td>

--- a/app/views/issues/_popover.html.erb
+++ b/app/views/issues/_popover.html.erb
@@ -1,0 +1,13 @@
+<% if value.kind_of? Hash %>
+  <ul>
+    <% value.each do |key, val| %>
+      <li><b><%= key %>:</b> <%= val %> </li>
+    <% end %>
+  </ul>
+<% else %>
+  <ul>
+    <% value.each do |val| %>
+      <li><%= val %></li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
Agrega un popover cuando detecta que el contenido de la celda es un array o un hash. 

Ejemplo:
![image](https://user-images.githubusercontent.com/36643035/171324927-7b8a7344-f53a-4c86-b012-15872602a427.png)

