### PR TITLE
GS-42_Fix_timezone_in_timeliness_config

### DIFF
--- a/config/initializers/timeliness.rb
+++ b/config/initializers/timeliness.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Timeliness.default_timezone = :local
+Timeliness.default_timezone = 'Buenos Aires'


### PR DESCRIPTION
Configura la zona horaria de Timeliness para que coincida con la de Rails