### PR TITLE
Fix licensed user limit validation

### DIFF
--- a/app/models/concerns/users/licenses.rb
+++ b/app/models/concerns/users/licenses.rb
@@ -8,7 +8,7 @@ module Users::Licenses
 
     before_save :check_licensed_user_limit, if: :should_check_licensed_user?
 
-    scope :licensed_user, -> { joins(:role).where(roles: { type: LICENSED_USERS }) }
+    scope :licensed_user, -> { visible.joins(:role).where(roles: { type: LICENSED_USERS }) }
   end
 
   private


### PR DESCRIPTION
Se soluciona el problema que impedía la creación de nuevos usuarios, aunque la cantidad de usuarios activos fuera menor al límite de licencias. El error ocurría porque no se excluían los usuarios eliminados (`hidden: true`) al contar las licencias utilizadas.